### PR TITLE
Market exit clarification.

### DIFF
--- a/insurancesimulation.py
+++ b/insurancesimulation.py
@@ -200,6 +200,7 @@ class InsuranceSimulation():
         
         # cumulative variables for history and logging
         self.cumulative_bankruptcies = 0
+        self.cumulative_market_exits = 0
         self.cumulative_unrecovered_claims = 0.0
         self.cumulative_claims = 0.0
         
@@ -681,6 +682,9 @@ class InsuranceSimulation():
 
     def record_bankruptcy(self):
         self.cumulative_bankruptcies += 1
+
+    def record_market_exit(self):
+        self.cumulative_market_exits += 1
 
     def record_unrecovered_claims(self, loss):
         self.cumulative_unrecovered_claims += loss

--- a/metainsuranceorg.py
+++ b/metainsuranceorg.py
@@ -219,7 +219,8 @@ class MetaInsuranceOrg(GenericAgent):
         self.risks_kept = []
         self.reinrisks_kept = []
         self.simulation.receive(self.cash)
-        self.cash = 0                           #Cash is 0 after bankruptcy or market exit.
+        obligation = {"amount": self.cash, "recipient": self.simulation, "due_time": time, "purpose": "Dissolution"}
+        self.pay(obligation)
         self.excess_capital = 0                 #Excess of capital is 0 after bankruptcy or market exit.
         self.profits_losses = 0                 #Profits and losses are 0 after bankruptcy or market exit.
         if self.operational:


### PR DESCRIPTION
Market exits are not bankruptcies. They should be treated differently.

A small bug in the record of bankruptcies is also solved.