### PR TITLE
Eliminate zombie reinsurance contracts after bankruptcy or market exit

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="VcsDirectoryMappings">
-    <mapping directory="$PROJECT_DIR$" vcs="Git" />
-  </component>
-</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/metainsuranceorg.py
+++ b/metainsuranceorg.py
@@ -270,9 +270,6 @@ class MetaInsuranceOrg(GenericAgent):
         if self.operational:
             method_to_call = getattr(self.simulation, record)
             method_to_call()
-        for category_reinsurance in self.category_reinsurance:
-            if category_reinsurance is not None:
-                category_reinsurance.dissolve(time)
         self.operational = False
 
     def receive_obligation(self, amount, recipient, due_time, purpose):

--- a/metainsuranceorg.py
+++ b/metainsuranceorg.py
@@ -270,6 +270,9 @@ class MetaInsuranceOrg(GenericAgent):
         if self.operational:
             method_to_call = getattr(self.simulation, record)
             method_to_call()
+        for category_reinsurance in self.category_reinsurance:
+            if category_reinsurance is not None:
+                category_reinsurance.dissolve(time)
         self.operational = False
 
     def receive_obligation(self, amount, recipient, due_time, purpose):


### PR DESCRIPTION
Eliminate zombie reinsurance contracts after bankruptcy or market exit. It does not make sense to keep them active after the default of the insurer. 